### PR TITLE
Add Azure storage and Web PubSub helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# realtime-quiz# Real-Time Collaborative Quiz App (Azure Web App + Azure Web PubSub)
+# Real-Time Collaborative Quiz App (Azure Web App + Azure Web PubSub)
 
 This is a starter repo for a two-player, real-time quiz game. It uses:
 - **Node.js + Express** for the API and static hosting
@@ -6,6 +6,10 @@ This is a starter repo for a two-player, real-time quiz game. It uses:
 - **(Optional) Azure Blob Storage** to persist uploaded quizzes by sessionId
 
 > If you specifically need **Azure SignalR Service**, consider a .NET server or an Azure Functions (JavaScript) hub. For Node servers, **Azure Web PubSub** is the most straightforward choice and functionally equivalent for this use case.
+
+## Requirements
+
+- Node.js 18 or newer
 
 ## Quick Start (Local)
 1. `npm install`

--- a/package.json
+++ b/package.json
@@ -9,11 +9,14 @@
   },
   "dependencies": {
     "@azure/storage-blob": "^12.18.0",
-    "@azure/web-pubsub": "^1.5.0",
+    "@azure/web-pubsub": "^1.0.0",
     "@azure/web-pubsub-socket.io": "^1.0.0",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "socket.io": "^4.7.5"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }

--- a/server/storage.js
+++ b/server/storage.js
@@ -1,0 +1,39 @@
+import { BlobServiceClient } from "@azure/storage-blob";
+
+const memoryStore = new Map();
+let containerClient;
+
+if (process.env.BLOB_CONNECTION_STRING) {
+  try {
+    const blobService = BlobServiceClient.fromConnectionString(process.env.BLOB_CONNECTION_STRING);
+    containerClient = blobService.getContainerClient("quizzes");
+    await containerClient.createIfNotExists();
+  } catch (err) {
+    console.error("Failed to initialize Azure Blob Storage, falling back to in-memory store", err);
+    containerClient = undefined;
+  }
+}
+
+export async function saveQuizJson(sessionId, quiz) {
+  if (containerClient) {
+    const data = JSON.stringify(quiz);
+    const blockClient = containerClient.getBlockBlobClient(`${sessionId}.json`);
+    await blockClient.upload(data, Buffer.byteLength(data), {
+      blobHTTPHeaders: { blobContentType: "application/json" }
+    });
+  } else {
+    memoryStore.set(sessionId, quiz);
+  }
+}
+
+export async function getQuizJson(sessionId) {
+  if (containerClient) {
+    const blockClient = containerClient.getBlockBlobClient(`${sessionId}.json`);
+    const exists = await blockClient.exists();
+    if (!exists) return null;
+    const buffer = await blockClient.downloadToBuffer();
+    return JSON.parse(buffer.toString());
+  } else {
+    return memoryStore.get(sessionId) || null;
+  }
+}

--- a/server/webpubsub.js
+++ b/server/webpubsub.js
@@ -1,0 +1,16 @@
+import { WebPubSubSocketIOAdapter } from "@azure/web-pubsub-socket.io";
+
+export async function attachWebPubSubAdapter(io) {
+  const connectionString = process.env.WEB_PUBSUB_CONNECTION_STRING;
+  if (!connectionString) {
+    console.warn("WEB_PUBSUB_CONNECTION_STRING not set; using default Socket.IO adapter");
+    return;
+  }
+  try {
+    const adapter = new WebPubSubSocketIOAdapter(connectionString, { hub: "quiz" });
+    io.adapter(adapter);
+  } catch (err) {
+    console.error("Failed to attach Web PubSub adapter", err);
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add Azure Blob storage helper with in-memory fallback
- add Azure Web PubSub Socket.IO adapter hookup
- require Node.js 18+ in package.json and docs

## Testing
- `npm install --dry-run`
- `npm test` *(fails: Missing script: "test")*
- `npm start` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_689e1426de7c832dba692e582c7120e1